### PR TITLE
FUCS President Involvement Updated

### DIFF
--- a/src/views/Resume.vue
+++ b/src/views/Resume.vue
@@ -65,7 +65,7 @@
                         <ul>
                             <li>General Member (2022 – Current)</li>
                             <li>Executive Member (Treasurer) (2022 – 2023)</li>
-                            <li>Executive Member (President) (2023 – Current)</li>
+                            <li>Executive Member (President) (2023 – 2024)</li>
                         </ul>
                         <li><strong>Flinders University:</strong></li>
                         <ul>


### PR DESCRIPTION
This pull request includes a small change to the `src/views/Resume.vue` file. The change updates the term for the "Executive Member (President)" position to reflect the correct current year.

* [`src/views/Resume.vue`](diffhunk://#diff-5a3a4b3b14a1b3e7db29540f6545ab27cab038b85e2507b575bfb033245093eaL68-R68): Updated the term for the "Executive Member (President)" position to "2023 – 2024".